### PR TITLE
Update security integration workflow permissions

### DIFF
--- a/.github/workflows/security_integration_check.yml
+++ b/.github/workflows/security_integration_check.yml
@@ -17,10 +17,10 @@ permissions:
   contents: read
   pull-requests: write
   security-events: read
+  id-token: write
 
 jobs:
   call-template:
     uses: curefit/actions-template/.github/workflows/security-workflow-template.yml@master
     with:
       branch: "${{ github.event.pull_request.head.ref || github.ref_name }}"
-    secrets: inherit


### PR DESCRIPTION
Remove `secrets: inherit` and add `id-token: write` in `.github/workflows/security_integration_check.yml`.