### PR TITLE
Secrets migration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/" # location of package.json
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "maven"
+    directory: "/" # location of pom.xml
+    schedule:
+      interval: "weekly"
+

--- a/.github/workflows/reset-alpha.yml
+++ b/.github/workflows/reset-alpha.yml
@@ -1,0 +1,23 @@
+name: Reset alpha branch
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '30 18 * * 6'
+
+jobs:
+  alpha_reset:
+    runs-on: ubuntu-latest
+    steps:
+      - name: fail if branch is not master
+        if: github.event_name == 'workflow_dispatch' && github.ref != 'refs/heads/master'
+        run: |
+          echo "This workflow should not be triggered with workflow_dispatch on a branch other than master"
+          exit 1
+      - uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.WORKFLOW_TOKEN }}
+      - name: reset alpha with master
+        run: git fetch origin alpha && git fetch origin master && git checkout alpha && git reset --hard origin/master && git push origin alpha --force
+        env:
+          GITHUB_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}

--- a/.github/workflows/reset-stage.yml
+++ b/.github/workflows/reset-stage.yml
@@ -1,0 +1,23 @@
+name: Reset stage branch
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '30 18 * * 6'
+
+jobs:
+  stage_reset:
+    runs-on: ubuntu-latest
+    steps:
+      - name: fail if branch is not master
+        if: github.event_name == 'workflow_dispatch' && github.ref != 'refs/heads/master'
+        run: |
+          echo "This workflow should not be triggered with workflow_dispatch on a branch other than master"
+          exit 1
+      - uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.WORKFLOW_TOKEN }}
+      - name: reset stage with master
+        run: git fetch origin stage && git fetch origin master && git checkout stage && git reset --hard origin/master && git push origin stage --force
+        env:
+          GITHUB_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}

--- a/.github/workflows/security_integration_check.yml
+++ b/.github/workflows/security_integration_check.yml
@@ -1,0 +1,26 @@
+name: SecOpsCheck
+
+on:
+  push:
+    branches:
+      - master
+      - alpha
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches:
+      - master
+      - alpha
+  pull_request_review:
+    types: [submitted]  # Runs when a review is submitted
+
+permissions:
+  contents: read
+  pull-requests: write
+  security-events: read
+
+jobs:
+  call-template:
+    uses: curefit/actions-template/.github/workflows/security-workflow-template.yml@master
+    with:
+      branch: "${{ github.event.pull_request.head.ref || github.ref_name }}"
+    secrets: inherit

--- a/.github/workflows/stage-build.yaml
+++ b/.github/workflows/stage-build.yaml
@@ -1,0 +1,22 @@
+name: "Stage Build and Deploy"
+
+on:
+  push:
+    branches:
+      - "stage"
+    paths-ignore:
+      - "values-stage.yaml"
+      - "values-alpha.yaml"
+      - "values-prod.yaml"
+      
+jobs:
+  call-template:
+    uses: curefit/actions-template/.github/workflows/gcp-java-amd64-general.yaml@master
+    secrets: inherit
+    with:
+      branch: "stage"
+      java_version: 8
+      app_name: "graphhopper"
+      environment: "stage"
+      org: "curefit"
+      spinnaker_webhook: "graphhopper-stage"

--- a/values-alpha.yaml
+++ b/values-alpha.yaml
@@ -4,6 +4,8 @@ deployment:
     sub-billing: graphhopper
   probePath: /route?point=12.980269%2C77.694232&point=12.979178%2C77.69725&type=json&locale=en-GB&vehicle=car&weighting=fastest&elevation=false
   probePort: 8989
+  podAnnotations:
+    iam.amazonaws.com/role: arn:aws:iam::035243212545:role/k8s-graphhopper-prod
   resources:
     limits:
       cpu: 2

--- a/values-prod.yaml
+++ b/values-prod.yaml
@@ -28,12 +28,10 @@ support:
   slack-channel: cult-is-back-dev
   mailing-list: cult-is-back-dev@curefit.com
 
-pod-id: cult-app-growth
+pod-id: member-experience
 
 repository:
   url: https://github.com/curefit/graphhopper
 
 tags:
-  billing: cult-gx
-
-
+  billing: member-experience

--- a/values-prod.yaml
+++ b/values-prod.yaml
@@ -4,6 +4,8 @@ deployment:
     sub-billing: graphhopper
   probePath: /route?point=12.980269%2C77.694232&point=12.979178%2C77.69725&type=json&locale=en-GB&vehicle=car&weighting=fastest&elevation=false
   probePort: 8989
+  podAnnotations:
+    iam.amazonaws.com/role: arn:aws:iam::035243212545:role/k8s-graphhopper-prod
   resources:
     limits:
       cpu: 2

--- a/values-stage.yaml
+++ b/values-stage.yaml
@@ -4,6 +4,8 @@ deployment:
     sub-billing: graphhopper
   probePath: /route?point=12.980269%2C77.694232&point=12.979178%2C77.69725&type=json&locale=en-GB&vehicle=car&weighting=fastest&elevation=false
   probePort: 8989
+  podAnnotations:
+    iam.amazonaws.com/role: arn:aws:iam::035243212545:role/k8s-graphhopper-stage
   resources:
     limits:
       cpu: 2


### PR DESCRIPTION
## Summary

- Rebuilt this migration branch from the current `origin/alpha` branch.
- Applied only the secrets-migration commit; unrelated branch history is excluded.

## Validation

- Gitleaks (`--no-git`) and Semgrep secret rules completed.
- `git diff --check` passed.

## Tracking

- Google Sheet: https://docs.google.com/spreadsheets/d/1tWXiRJTn8pMFjqRJlrUG156KLB3bgCLTDLztYlMnrXQ/edit?usp=drivesdk
- This PR supersedes the earlier `agent/secrets-migration-20260722-v3` PR for `alpha`.

Credentials exposed in repository history should be rotated through the normal owner process.