### PR TITLE
[codex] add submit-dependencies workflow

### DIFF
--- a/.github/workflows/submit-dependencies.yml
+++ b/.github/workflows/submit-dependencies.yml
@@ -1,0 +1,12 @@
+name: Submit Dependencies
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  submit-dependencies:
+    uses: curefit/actions-template/.github/workflows/submit-dependencies.yaml@master
+    with:
+      java_version: 8


### PR DESCRIPTION
## What changed
Added `.github/workflows/submit-dependencies.yml`.

## Why
This repo has a Maven build but was missing the dependency submission workflow used across Java repos.

## Notes
- Target branch trigger: `master`
- Java version: `8`

## Validation
- Verified the repo was missing this workflow before creating the PR.
- Derived the Java version from the repo's existing workflows or `pom.xml`.
